### PR TITLE
Enhanced system calls

### DIFF
--- a/R/check_namespace.R
+++ b/R/check_namespace.R
@@ -51,21 +51,25 @@ summarize_imports <- function(imported_packages, imported_functions) {
   if(length(imported_packages) > 0) {
     pkgs <- data.frame(type = "package", import = as.character(imported_packages), stringsAsFactors = FALSE)
   } else {
-    pkgs <- data.frame()
+    pkgs <- data.frame(type = character(0), import = character(0))
   }
 
   if(length(imported_functions) > 0) {
     funs <- data.frame(type = "function", import = as.character(imported_functions), stringsAsFactors = FALSE)
   } else {
-    funs <- data.frame()
+    funs <- data.frame(type = character(0), import = character(0))
   }
 
   all_imports <- rbind(pkgs, funs)
-  all_imports$package <- vapply(
-    strsplit(all_imports$import, "::"),
-    function(x) x[[1]],
-    "character"
-  )
+  if (nrow(all_imports) > 0) {
+    all_imports$package <- vapply(
+      strsplit(all_imports$import, "::"),
+      function(x) x[[1]],
+      "character"
+    )
+  } else {
+    all_imports$package <- character(0)
+  }
   all_imports
 }
 

--- a/R/check_namespace.R
+++ b/R/check_namespace.R
@@ -48,13 +48,13 @@ parse_all_imports <- function(imports_list) {
 }
 
 summarize_imports <- function(imported_packages, imported_functions) {
-  if(length(imported_packages) > 0) {
+  if (length(imported_packages) > 0) {
     pkgs <- data.frame(type = "package", import = as.character(imported_packages), stringsAsFactors = FALSE)
   } else {
     pkgs <- data.frame(type = character(0), import = character(0))
   }
 
-  if(length(imported_functions) > 0) {
+  if (length(imported_functions) > 0) {
     funs <- data.frame(type = "function", import = as.character(imported_functions), stringsAsFactors = FALSE)
   } else {
     funs <- data.frame(type = character(0), import = character(0))

--- a/R/system_calls.R
+++ b/R/system_calls.R
@@ -30,16 +30,29 @@ digest_system_calls <- function(r_file, path, calls_to_flag = system_calls()) {
     return(result)
   }
   result$path <- sub(paste0("^", path, "/"), "", r_file)
-  subset(result, select = c("path", "line1", "text")) %>%
-    magrittr::set_names(c("path", "line_number", "function_name"))
+  subset(result, select = c("path", "line1", "text", "function_name")) %>%
+    magrittr::set_names(c("path", "line_number", "call", "function_name"))
 }
 
 find_system_calls <- function(expr, calls_to_flag = system_calls()) {
-  withr::with_options(
+  parsed_data <- withr::with_options(
     c("keep.source" = TRUE),
-    utils::getParseData(expr)
-  ) %>%
-    subset(.$token == "SYMBOL_FUNCTION_CALL") %>%
-    subset(.$text %in% calls_to_flag) %>%
+    utils::getParseData(expr, includeText = TRUE)
+  )
+
+  base_fun_row_indexes <- which(
+    (parsed_data$token == "SYMBOL_FUNCTION_CALL") & (parsed_data$text %in% calls_to_flag)
+  )
+  base_sys_calls <- parsed_data[base_fun_row_indexes - 1, ]
+  base_sys_calls$function_name <- parsed_data[base_fun_row_indexes, ]$text
+
+  pkg_fun_row_indexes <- which(
+    (parsed_data$token == "expr") & (parsed_data$text %in% calls_to_flag[grepl("::", calls_to_flag)])
+  )
+  pkg_sys_calls <- parsed_data[pkg_fun_row_indexes - 1, ]
+  pkg_sys_calls$function_name <- parsed_data[pkg_fun_row_indexes, ]$text
+
+  rbind(base_sys_calls, pkg_sys_calls) %>%
     `row.names<-`(NULL)
+
 }

--- a/R/system_calls.R
+++ b/R/system_calls.R
@@ -54,5 +54,4 @@ find_system_calls <- function(expr, calls_to_flag = system_calls()) {
 
   rbind(base_sys_calls, pkg_sys_calls) %>%
     `row.names<-`(NULL)
-
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,11 @@ dangerous_imports <- function(additional_dangerous_imports = character(0)) {
 #'
 #' @examples system_calls("exec_background")
 system_calls <- function(additional_system_calls = character(0)) {
-  c(base_system_calls(), "run", additional_system_calls) %>%
+  c(
+    base_system_calls(),
+    "processx::run", "sys::exec_internal",
+    additional_system_calls
+  ) %>%
     unique()
 }
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,32 @@
 
 ![](./man/figures/supergb.png)
 
-# rOpenSci Unconf 18 Project : defender
+rOpenSci Unconf 18 Project : defender
+=====================================
 
-## Authors:
+Authors:
+--------
 
-  - Ildiko Czeller
-  - Karthik Ram
-  - Bob Rudis
-  - Kara Woo
+-   Ildiko Czeller
+-   Karthik Ram
+-   Bob Rudis
+-   Kara Woo
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+defender <img src="man/figures/logo.png" align="right"/>
+========================================================
 
-# defender <img src="man/figures/logo.png" align="right"/>
+[![Travis build status](https://travis-ci.org/ropenscilabs/defender.svg?branch=master)](https://travis-ci.org/ropenscilabs/defender) [![Coverage status](https://img.shields.io/codecov/c/github/ropenscilabs/defender/master.svg)](https://codecov.io/github/ropenscilabs/defender?branch=master)
 
-[![Travis build
-status](https://travis-ci.org/ropenscilabs/defender.svg?branch=master)](https://travis-ci.org/ropenscilabs/defender)
-[![Coverage
-status](https://img.shields.io/codecov/c/github/ropenscilabs/defender/master.svg)](https://codecov.io/github/ropenscilabs/defender?branch=master)
-
-The goal of defender is to do static code analysis on other R packages
-to check for potential security risks and best practices. It provides
-checks on multiple levels:
+The goal of defender is to do static code analysis on other R packages to check for potential security risks and best practices. It provides checks on multiple levels:
 
 1.  \[x\] static code analysis without installing the package
-2.  \[ \] more thorough but potentially dangerous checks with
-    installation / in Docker container
+2.  \[ \] more thorough but potentially dangerous checks with installation / in Docker container
 
-The checks do not tell you whether something is harmful but rather they
-flag code that you should double-check before running / loading the
-package.
+The checks do not tell you whether something is harmful but rather they flag code that you should double-check before running / loading the package.
 
-## Installation
+Installation
+------------
 
 You can install defender from github with:
 
@@ -40,7 +35,8 @@ You can install defender from github with:
 devtools::install_github("ropenscilabs/defender")
 ```
 
-## Example
+Example
+-------
 
 ### System calls in R scripts
 
@@ -48,14 +44,24 @@ You can check for system calls in any directory locally available:
 
 ``` r
 defender::summarize_system_calls("../testevil")
-#>                path line_number function_name
-#> 1   inst/root_sys.R           1       system2
-#> 2   inst/root_sys.R           4        system
-#> 3      R/exported.R           7       system2
-#> 4      R/internal.R           4        system
-#> 5      R/internal.R           8        system
-#> 6      R/processx.R           3           run
-#> 7 R/system_hidden.R           2       system2
+#>                path line_number                     call
+#> 1   inst/root_sys.R           1            system2("ls")
+#> 2   inst/root_sys.R           4             system("ls")
+#> 3      R/exported.R           7            system2("ls")
+#> 4      R/internal.R           4             system("ls")
+#> 5      R/internal.R           8         system("ls -la")
+#> 6      R/processx.R           3      processx::run("ls")
+#> 7           R/sys.R           8 sys::exec_internal("ls")
+#> 8 R/system_hidden.R           2            system2("lm")
+#>        function_name
+#> 1            system2
+#> 2             system
+#> 3            system2
+#> 4             system
+#> 5             system
+#> 6      processx::run
+#> 7 sys::exec_internal
+#> 8            system2
 ```
 
 You can also include additional elements to flag as dangerous:
@@ -63,15 +69,26 @@ You can also include additional elements to flag as dangerous:
 ``` r
 sc <- defender::system_calls("poll")
 defender::summarize_system_calls("../testevil", calls_to_flag = sc)
-#>                path line_number function_name
-#> 1   inst/root_sys.R           1       system2
-#> 2   inst/root_sys.R           4        system
-#> 3      R/exported.R           7       system2
-#> 4      R/internal.R           4        system
-#> 5      R/internal.R           8        system
-#> 6      R/processx.R           3           run
-#> 7      R/processx.R           9          poll
-#> 8 R/system_hidden.R           2       system2
+#>                path line_number                     call
+#> 1   inst/root_sys.R           1            system2("ls")
+#> 2   inst/root_sys.R           4             system("ls")
+#> 3      R/exported.R           7            system2("ls")
+#> 4      R/internal.R           4             system("ls")
+#> 5      R/internal.R           8         system("ls -la")
+#> 6      R/processx.R           9               poll("ls")
+#> 7      R/processx.R           3      processx::run("ls")
+#> 8           R/sys.R           8 sys::exec_internal("ls")
+#> 9 R/system_hidden.R           2            system2("lm")
+#>        function_name
+#> 1            system2
+#> 2             system
+#> 3            system2
+#> 4             system
+#> 5             system
+#> 6               poll
+#> 7      processx::run
+#> 8 sys::exec_internal
+#> 9            system2
 ```
 
 ### System-related imports in NAMESPACE
@@ -98,9 +115,10 @@ defender::check_namespace("../testevil", imports_to_flag = di)
 #> 4 function  processx::run processx
 ```
 
-## Collaborators
+Collaborators
+-------------
 
-  - Ildi Czeller @czeildi
-  - Karthik Ram @karthik
-  - Bob Rudis @hrbrmstr
-  - Kara Woo @karawoo
+-   Ildi Czeller @czeildi
+-   Karthik Ram @karthik
+-   Bob Rudis @hrbrmstr
+-   Kara Woo @karawoo

--- a/tests/testthat/test-check_namespace.R
+++ b/tests/testthat/test-check_namespace.R
@@ -7,6 +7,7 @@ setup({
 })
 
 teardown({
+  td <- file.path(normalizePath("."), "testdir")
   unlink(td, recursive = TRUE)
 })
 
@@ -55,6 +56,10 @@ test_that("parse namespace file", {
     all(c("imports", "exports") %in% names(parse_ns_file(td)))
   )
   unlink(td, recursive = TRUE)
+})
+
+test_that("summarize imports handles empty import list", {
+  expect_silent(summarize_imports(list(), list()))
 })
 
 test_that("summarize imports returns data frame", {

--- a/tests/testthat/test-system_calls.R
+++ b/tests/testthat/test-system_calls.R
@@ -18,14 +18,6 @@ test_that("expression is parsed to data frame", {
 })
 
 
-test_that("find system calls returns rows of getParseData with only function calls", {
-  expect_setequal(
-    find_system_calls(parse(text = "system2()"))$token,
-    "SYMBOL_FUNCTION_CALL"
-  )
-})
-
-
 test_that("find system calls does not return plain functions calls", {
   expect_equal(
     nrow(find_system_calls(parse(text = "foo()\nsystem2()\nsystem()"))),


### PR DESCRIPTION
Fixes (?) #15 

Now `summarize_system_calls` shows system calls from packages with fully qualified references, not only base system calls.

The used function and the whole code is shown as well.

example:

``` r
sc <- defender::system_calls("poll")
defender::summarize_system_calls("../testevil", calls_to_flag = sc)
#>                path line_number                     call
#> 1   inst/root_sys.R           1            system2("ls")
#> 2   inst/root_sys.R           4             system("ls")
#> 3      R/exported.R           7            system2("ls")
#> 4      R/internal.R           4             system("ls")
#> 5      R/internal.R           8         system("ls -la")
#> 6      R/processx.R           9               poll("ls")
#> 7      R/processx.R           3      processx::run("ls")
#> 8           R/sys.R           8 sys::exec_internal("ls")
#> 9 R/system_hidden.R           2            system2("lm")
#>        function_name
#> 1            system2
#> 2             system
#> 3            system2
#> 4             system
#> 5             system
#> 6               poll
#> 7      processx::run
#> 8 sys::exec_internal
#> 9            system2
```

@hrbrmstr  I could not find how `getParseText` is different from the text column of `getParseData`. Is there a reason I should use `getParseText`?